### PR TITLE
Fix broken import path for feature-signals in API routes

### DIFF
--- a/frontend/app/api/checkin/submit/route.ts
+++ b/frontend/app/api/checkin/submit/route.ts
@@ -3,7 +3,7 @@ import dbConnect from '@/lib/db';
 import { verifyToken } from '@/lib/auth';
 import { getDayKey } from '@/lib/progression';
 import { adjustUserXP } from '@/lib/user-progress';
-import { recordFeatureSignals } from '@/lib/feature-signals';
+import { recordFeatureSignals } from '@/lib/neon/feature-signals';
 import CheckIn from '@/lib/models/CheckIn';
 
 export const dynamic = 'force-dynamic';

--- a/frontend/app/api/quest/complete/[id]/route.ts
+++ b/frontend/app/api/quest/complete/[id]/route.ts
@@ -4,7 +4,7 @@ import dbConnect from '@/lib/db';
 import { verifyToken } from '@/lib/auth';
 import { normalizeDuration, QUEST_XP_REWARD } from '@/lib/progression';
 import { adjustUserXP } from '@/lib/user-progress';
-import { recordFeatureSignals } from '@/lib/feature-signals';
+import { recordFeatureSignals } from '@/lib/neon/feature-signals';
 import Quest from '@/lib/models/Quest';
 
 export const dynamic = 'force-dynamic';

--- a/frontend/app/api/quest/create/route.ts
+++ b/frontend/app/api/quest/create/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import dbConnect from '@/lib/db';
 import { verifyToken } from '@/lib/auth';
 import { normalizeDuration } from '@/lib/progression';
-import { recordFeatureSignals } from '@/lib/feature-signals';
+import { recordFeatureSignals } from '@/lib/neon/feature-signals';
 import Quest from '@/lib/models/Quest';
 
 export const dynamic = 'force-dynamic';

--- a/frontend/app/api/quest/progress/[id]/route.ts
+++ b/frontend/app/api/quest/progress/[id]/route.ts
@@ -4,7 +4,7 @@ import dbConnect from '@/lib/db';
 import { verifyToken } from '@/lib/auth';
 import { normalizeDuration, QUEST_XP_REWARD } from '@/lib/progression';
 import { adjustUserXP } from '@/lib/user-progress';
-import { recordFeatureSignals } from '@/lib/feature-signals';
+import { recordFeatureSignals } from '@/lib/neon/feature-signals';
 import Quest from '@/lib/models/Quest';
 
 export const dynamic = 'force-dynamic';


### PR DESCRIPTION
Updated the import path for `recordFeatureSignals` in `frontend/app/api/checkin/submit/route.ts` and related quest API routes.
The correct path is `@/lib/neon/feature-signals`, not `@/lib/feature-signals`.

Verified by running `npx tsc --noEmit` in the `frontend` directory, confirming that the `Cannot find module` errors for `feature-signals` are resolved.

---
*PR created automatically by Jules for task [336261909836724518](https://jules.google.com/task/336261909836724518) started by @longMengchheang*