### PR TITLE
🔒 Fix hardcoded JWT secret vulnerability in auth.ts

### DIFF
--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -1,6 +1,10 @@
-﻿import jwt from 'jsonwebtoken';
+import jwt from 'jsonwebtoken';
 
-const JWT_SECRET = process.env.JWT_SECRET || '4a8f5b3e2c1d9e7f6a5b4c3d2e1f0a9';
+if (!process.env.JWT_SECRET) {
+  throw new Error('JWT_SECRET is not defined');
+}
+
+const JWT_SECRET = process.env.JWT_SECRET;
 
 export interface DecodedUser {
   id: string;


### PR DESCRIPTION
This PR fixes a critical security vulnerability where a hardcoded JWT secret was used as a fallback.
If `JWT_SECRET` was not set in the environment, the application would use a publicly known secret, allowing attackers to forge tokens.

Changes:
- Removed the fallback string for `JWT_SECRET`.
- Added a runtime check to throw an error if `JWT_SECRET` is missing.

Verification:
- Verified that the application throws an error when `JWT_SECRET` is missing.
- Verified that the application works correctly when `JWT_SECRET` is set.
- Ran existing tests to ensure no regressions.

---
*PR created automatically by Jules for task [15438468967758212274](https://jules.google.com/task/15438468967758212274) started by @longMengchheang*