### PR TITLE
🧪 Add tests for getMoodFromCheckIn in progression.ts

### DIFF
--- a/frontend/lib/progression.test.ts
+++ b/frontend/lib/progression.test.ts
@@ -1,5 +1,5 @@
 import { expect, test, describe } from "bun:test";
-import { applyXPDelta } from "./progression";
+import { applyXPDelta, getMoodFromCheckIn } from "./progression";
 
 describe("applyXPDelta", () => {
   test("should gain XP without leveling up", () => {
@@ -105,5 +105,53 @@ describe("applyXPDelta", () => {
       currentXP: 20,
       requiredXP: 100,
     });
+  });
+});
+
+describe("getMoodFromCheckIn", () => {
+  test("should return 'Excellent' for scores >= 80%", () => {
+    expect(getMoodFromCheckIn(20, 25)).toEqual({ emoji: '🤩', label: 'Excellent' }); // 80%
+    expect(getMoodFromCheckIn(25, 25)).toEqual({ emoji: '🤩', label: 'Excellent' }); // 100%
+  });
+
+  test("should return 'Great' for scores >= 60% and < 80%", () => {
+    expect(getMoodFromCheckIn(15, 25)).toEqual({ emoji: '😄', label: 'Great' }); // 60%
+    expect(getMoodFromCheckIn(19, 25)).toEqual({ emoji: '😄', label: 'Great' }); // 76%
+  });
+
+  test("should return 'Good' for scores >= 40% and < 60%", () => {
+    expect(getMoodFromCheckIn(10, 25)).toEqual({ emoji: '🙂', label: 'Good' }); // 40%
+    expect(getMoodFromCheckIn(14, 25)).toEqual({ emoji: '🙂', label: 'Good' }); // 56%
+  });
+
+  test("should return 'Neutral' for scores >= 20% and < 40%", () => {
+    expect(getMoodFromCheckIn(5, 25)).toEqual({ emoji: '😐', label: 'Neutral' }); // 20%
+    expect(getMoodFromCheckIn(9, 25)).toEqual({ emoji: '😐', label: 'Neutral' }); // 36%
+  });
+
+  test("should return 'Low' for scores < 20%", () => {
+    expect(getMoodFromCheckIn(0, 25)).toEqual({ emoji: '😟', label: 'Low' }); // 0%
+    expect(getMoodFromCheckIn(4, 25)).toEqual({ emoji: '😟', label: 'Low' }); // 16%
+  });
+
+  test("should handle custom max score", () => {
+    // 80/100 = 80% -> Excellent
+    expect(getMoodFromCheckIn(80, 100)).toEqual({ emoji: '🤩', label: 'Excellent' });
+    // 50/100 = 50% -> Good
+    expect(getMoodFromCheckIn(50, 100)).toEqual({ emoji: '🙂', label: 'Good' });
+  });
+
+  test("should return 'Neutral' if maxScore is 0", () => {
+    expect(getMoodFromCheckIn(10, 0)).toEqual({ emoji: '😐', label: 'Neutral' });
+  });
+
+  test("should return 'Excellent' if score > maxScore", () => {
+    // 30/25 = 120% -> Excellent
+    expect(getMoodFromCheckIn(30, 25)).toEqual({ emoji: '🤩', label: 'Excellent' });
+  });
+
+  test("should return 'Low' if score is negative", () => {
+    // -5/25 = -20% -> Low
+    expect(getMoodFromCheckIn(-5, 25)).toEqual({ emoji: '😟', label: 'Low' });
   });
 });


### PR DESCRIPTION
🧪 **What:** Added unit tests for `getMoodFromCheckIn` in `frontend/lib/progression.ts`.
📊 **Coverage:**
- Default max score (25): Verified Excellent, Great, Good, Neutral, Low ranges.
- Custom max score: Verified correct mood calculation.
- Edge cases: Verified behavior for maxScore 0, negative scores, and scores exceeding maxScore.
✨ **Result:** Increased test coverage for the progression library, ensuring the mood calculation logic is robust and correct.

---
*PR created automatically by Jules for task [2896551547984712784](https://jules.google.com/task/2896551547984712784) started by @longMengchheang*