### PR TITLE
🧪 Add tests for getRequiredXP in progression.ts

### DIFF
--- a/frontend/lib/progression.test.ts
+++ b/frontend/lib/progression.test.ts
@@ -1,5 +1,32 @@
 import { expect, test, describe } from "bun:test";
-import { applyXPDelta } from "./progression";
+import { applyXPDelta, getRequiredXP } from "./progression";
+
+describe("getRequiredXP", () => {
+  test("should return base XP for level 1", () => {
+    expect(getRequiredXP(1)).toBe(100);
+  });
+
+  test("should calculate correct XP for higher levels", () => {
+    expect(getRequiredXP(2)).toBe(125);
+    expect(getRequiredXP(5)).toBe(200);
+    expect(getRequiredXP(10)).toBe(325);
+  });
+
+  test("should normalize level less than 1 to level 1", () => {
+    expect(getRequiredXP(0)).toBe(100);
+    expect(getRequiredXP(-5)).toBe(100);
+  });
+
+  test("should handle decimal levels by flooring", () => {
+    expect(getRequiredXP(1.5)).toBe(100); // Level 1
+    expect(getRequiredXP(2.9)).toBe(125); // Level 2
+  });
+
+  test("should handle non-finite numbers by defaulting to level 1", () => {
+    expect(getRequiredXP(Infinity)).toBe(100);
+    expect(getRequiredXP(NaN)).toBe(100);
+  });
+});
 
 describe("applyXPDelta", () => {
   test("should gain XP without leveling up", () => {


### PR DESCRIPTION
🎯 **What:** add unit tests for getRequiredXP in progression.ts
📊 **Coverage:**
- Standard levels (1, 2, 5, 10)
- Edge cases (0, negative, decimal)
- Non-finite inputs (Infinity, NaN)
✨ **Result:** Increased test coverage for game progression logic, preventing regressions in XP calculations.

---
*PR created automatically by Jules for task [12935151855902617715](https://jules.google.com/task/12935151855902617715) started by @longMengchheang*