### PR TITLE
🧪 Add tests for sanitizeExtractedSignals in chatSignals.ts

### DIFF
--- a/frontend/lib/chatSignals.test.ts
+++ b/frontend/lib/chatSignals.test.ts
@@ -1,5 +1,5 @@
 import { expect, test, describe } from "bun:test";
-import { normalizeSignalType, CHAT_SIGNAL_TYPES } from "./chatSignals";
+import { normalizeSignalType, CHAT_SIGNAL_TYPES, sanitizeExtractedSignals } from "./chatSignals";
 
 describe("normalizeSignalType", () => {
   describe("Exact Matches", () => {
@@ -72,6 +72,141 @@ describe("normalizeSignalType", () => {
 
     test("should handle objects gracefully", () => {
         expect(normalizeSignalType({})).toBeNull();
+    });
+  });
+});
+
+describe("sanitizeExtractedSignals", () => {
+  describe("Basic Valid Input", () => {
+    test("should extract valid signals from array", () => {
+      const input = [
+        { signalType: "stress", intensity: 4, confidence: 0.8 },
+        { signalType: "focus", intensity: 3, confidence: 0.9 },
+      ];
+      const result = sanitizeExtractedSignals(input);
+      expect(result).toHaveLength(2);
+      expect(result).toContainEqual({ signalType: "stress", intensity: 4, confidence: 0.8 });
+      expect(result).toContainEqual({ signalType: "focus", intensity: 3, confidence: 0.9 });
+    });
+  });
+
+  describe("Input Normalization", () => {
+    test("should normalize signal types, aliases and mixed case", () => {
+      const input = [
+        { signalType: "Stressed", intensity: 4, confidence: 0.8 },
+        { signal_type: "concentration", intensity: 3, confidence: 0.9 },
+        { type: "TIRED", intensity: 2, confidence: 0.6 },
+      ];
+      const result = sanitizeExtractedSignals(input);
+      expect(result).toHaveLength(3);
+      expect(result).toContainEqual({ signalType: "stress", intensity: 4, confidence: 0.8 });
+      expect(result).toContainEqual({ signalType: "focus", intensity: 3, confidence: 0.9 });
+      expect(result).toContainEqual({ signalType: "fatigue", intensity: 2, confidence: 0.6 });
+    });
+
+    test("should handle string numbers for intensity and confidence", () => {
+      const input = [{ signalType: "stress", intensity: "4", confidence: "0.8" }];
+      const result = sanitizeExtractedSignals(input);
+      expect(result).toContainEqual({ signalType: "stress", intensity: 4, confidence: 0.8 });
+    });
+  });
+
+  describe("Defaults and Clamping", () => {
+    test("should use defaults for missing values", () => {
+      const input = [{ signalType: "stress" }];
+      const result = sanitizeExtractedSignals(input);
+      expect(result[0]).toEqual({ signalType: "stress", intensity: 3, confidence: 0.7 });
+    });
+
+    test("should clamp intensity between 1 and 5", () => {
+      const input = [
+        { signalType: "stress", intensity: 0 },
+        { signalType: "focus", intensity: 10 },
+      ];
+      const result = sanitizeExtractedSignals(input);
+      const stress = result.find((s) => s.signalType === "stress");
+      const focus = result.find((s) => s.signalType === "focus");
+      expect(stress?.intensity).toBe(1);
+      expect(focus?.intensity).toBe(5);
+    });
+
+    test("should clamp confidence between 0 and 1", () => {
+      const input = [
+        { signalType: "stress", confidence: -0.5 },
+        { signalType: "focus", confidence: 1.5 },
+      ];
+      const result = sanitizeExtractedSignals(input);
+      const stress = result.find((s) => s.signalType === "stress");
+      const focus = result.find((s) => s.signalType === "focus");
+      expect(stress?.confidence).toBe(0);
+      expect(focus?.confidence).toBe(1);
+    });
+  });
+
+  describe("Wrapper Object Support", () => {
+    test("should extract from 'signals' property", () => {
+      const input = { signals: [{ signalType: "stress", intensity: 4 }] };
+      const result = sanitizeExtractedSignals(input);
+      expect(result).toHaveLength(1);
+      expect(result[0].signalType).toBe("stress");
+    });
+
+    test("should extract from 'data' property", () => {
+      const input = { data: [{ signalType: "stress", intensity: 4 }] };
+      const result = sanitizeExtractedSignals(input);
+      expect(result).toHaveLength(1);
+      expect(result[0].signalType).toBe("stress");
+    });
+  });
+
+  describe("Deduplication", () => {
+    test("should keep signal with higher confidence", () => {
+      const input = [
+        { signalType: "stress", intensity: 3, confidence: 0.5 },
+        { signalType: "stress", intensity: 4, confidence: 0.8 },
+      ];
+      const result = sanitizeExtractedSignals(input);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({ signalType: "stress", intensity: 4, confidence: 0.8 });
+    });
+
+    test("should keep signal with higher intensity if confidence is equal", () => {
+      const input = [
+        { signalType: "stress", intensity: 3, confidence: 0.8 },
+        { signalType: "stress", intensity: 5, confidence: 0.8 },
+      ];
+      const result = sanitizeExtractedSignals(input);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({ signalType: "stress", intensity: 5, confidence: 0.8 });
+    });
+
+    test("should handle mixed order updates", () => {
+      // High confidence first, then lower confidence
+      const input = [
+        { signalType: "stress", intensity: 4, confidence: 0.9 },
+        { signalType: "stress", intensity: 3, confidence: 0.5 },
+      ];
+      const result = sanitizeExtractedSignals(input);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({ signalType: "stress", intensity: 4, confidence: 0.9 });
+    });
+  });
+
+  describe("Edge Cases/Invalid Input", () => {
+    test("should return empty array for null/undefined", () => {
+      expect(sanitizeExtractedSignals(null)).toEqual([]);
+      expect(sanitizeExtractedSignals(undefined)).toEqual([]);
+    });
+
+    test("should return empty array for empty object", () => {
+      expect(sanitizeExtractedSignals({})).toEqual([]);
+    });
+
+    test("should ignore invalid items in array", () => {
+      const input = [null, "invalid", { invalid: "object" }, { signalType: "stress", intensity: 4, confidence: 0.8 }];
+      const result = sanitizeExtractedSignals(input);
+      expect(result).toHaveLength(1);
+      expect(result[0].signalType).toBe("stress");
     });
   });
 });


### PR DESCRIPTION
🎯 **What:** Added unit tests for `sanitizeExtractedSignals` in `frontend/lib/chatSignals.ts`.
📊 **Coverage:**
- Basic valid input arrays.
- Normalization of signal types, aliases, and string numbers.
- Default values and clamping for intensity (1-5) and confidence (0-1).
- Handling of wrapper objects (`{ signals: ... }`, `{ data: ... }`).
- Deduplication logic prioritizing higher confidence, then higher intensity.
- Edge cases like `null`, `undefined`, empty objects, and invalid array items.
✨ **Result:** Increased test coverage and confidence in the chat signal sanitization logic.

---
*PR created automatically by Jules for task [9170912124622039377](https://jules.google.com/task/9170912124622039377) started by @longMengchheang*