### PR TITLE
Add email format validation to registration endpoint

### DIFF
--- a/frontend/app/api/auth/register/route.ts
+++ b/frontend/app/api/auth/register/route.ts
@@ -2,7 +2,7 @@
 import { NextResponse } from 'next/server';
 import dbConnect from '@/lib/db';
 import { signToken } from '@/lib/auth';
-import { validatePassword } from '@/lib/validation';
+import { validatePassword, validateEmail } from '@/lib/validation';
 import { getRequiredXP } from '@/lib/progression';
 import User from '@/lib/models/User';
 
@@ -35,6 +35,11 @@ export async function POST(req: Request) {
 
     if (!email || !password) {
       return NextResponse.json({ msg: 'Email and password are required.' }, { status: 400 });
+    }
+
+    const emailValidation = validateEmail(email);
+    if (!emailValidation.isValid) {
+      return NextResponse.json({ msg: emailValidation.message }, { status: 400 });
     }
 
     const passwordValidation = validatePassword(password);

--- a/frontend/lib/progression.test.ts
+++ b/frontend/lib/progression.test.ts
@@ -1,5 +1,5 @@
 import { expect, test, describe } from "bun:test";
-import { applyXPDelta, getRequiredXP } from "./progression";
+import { applyXPDelta, getRequiredXP, computeDailyStreak, deriveBadges, type BadgeContext, getMoodFromCheckIn } from "./progression";
 
 describe("getRequiredXP", () => {
   test("should return base XP for level 1", () => {
@@ -27,8 +27,6 @@ describe("getRequiredXP", () => {
     expect(getRequiredXP(NaN)).toBe(100);
   });
 });
-import { applyXPDelta, computeDailyStreak } from "./progression";
-import { applyXPDelta, deriveBadges, type BadgeContext } from "./progression";
 
 describe("applyXPDelta", () => {
   test("should gain XP without leveling up", () => {
@@ -201,6 +199,9 @@ describe("computeDailyStreak", () => {
       new Date("2023-12-31T10:00:00"),
     ];
     expect(computeDailyStreak(dates)).toBe(2);
+  });
+});
+
 describe("deriveBadges", () => {
   const baseContext: BadgeContext = {
     totalQuests: 0,
@@ -288,6 +289,9 @@ describe("deriveBadges", () => {
     const badges = deriveBadges(context);
     expect(badges).toContain("First Quest");
     expect(badges.filter((b) => b === "First Quest").length).toBe(1);
+  });
+});
+
 describe("getMoodFromCheckIn", () => {
   test("should return 'Excellent' for scores >= 80%", () => {
     expect(getMoodFromCheckIn(20, 25)).toEqual({ emoji: '🤩', label: 'Excellent' }); // 80%

--- a/frontend/lib/validation.test.ts
+++ b/frontend/lib/validation.test.ts
@@ -1,5 +1,5 @@
 import { expect, test, describe } from "bun:test";
-import { validatePassword } from "./validation";
+import { validatePassword, validateEmail } from "./validation";
 
 describe("validatePassword", () => {
   test("should reject short passwords", () => {
@@ -40,5 +40,22 @@ describe("validatePassword", () => {
   test("should accept valid passwords with spaces as special characters", () => {
     const result = validatePassword("Space is special 1A");
     expect(result.isValid).toBe(true);
+  });
+});
+
+describe("validateEmail", () => {
+  test("should accept valid emails", () => {
+    expect(validateEmail("test@example.com").isValid).toBe(true);
+    expect(validateEmail("user.name@domain.co.uk").isValid).toBe(true);
+    expect(validateEmail("user+tag@domain.com").isValid).toBe(true);
+  });
+
+  test("should reject invalid emails", () => {
+    expect(validateEmail("invalid-email").isValid).toBe(false);
+    expect(validateEmail("user@domain").isValid).toBe(false);
+    expect(validateEmail("@domain.com").isValid).toBe(false);
+    expect(validateEmail("user@.com").isValid).toBe(false);
+    expect(validateEmail("user@domain.").isValid).toBe(false);
+    expect(validateEmail("").isValid).toBe(false);
   });
 });

--- a/frontend/lib/validation.ts
+++ b/frontend/lib/validation.ts
@@ -25,3 +25,14 @@ export function validatePassword(password: string): { isValid: boolean; message:
   }
   return { isValid: true, message: '' };
 }
+
+/**
+ * Validates an email address format.
+ */
+export function validateEmail(email: string): { isValid: boolean; message: string } {
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailRegex.test(email)) {
+    return { isValid: false, message: 'Invalid email format.' };
+  }
+  return { isValid: true, message: '' };
+}


### PR DESCRIPTION
This PR addresses a security vulnerability where the registration endpoint did not validate the email format.

**Changes:**
1.  **Implemented `validateEmail`:** A reusable function in `frontend/lib/validation.ts` that uses a regex to check for valid email format.
2.  **Updated Registration Route:** The `POST` handler in `frontend/app/api/auth/register/route.ts` now calls `validateEmail` before creating a user. It returns a 400 error if the email is invalid.
3.  **Added Tests:** Unit tests for `validateEmail` cover valid and invalid email scenarios.
4.  **Fixed Existing Tests:** Corrected syntax errors and missing imports in `frontend/lib/progression.test.ts` to ensure the full test suite passes.

**Risk:**
Without this validation, users could register with malformed email addresses, potentially causing issues with email delivery, data integrity, or downstream services that expect valid emails.

**Verification:**
- Ran `bun test frontend/lib/validation.test.ts` to verify the new validation logic.
- Ran `bun test` to ensure no regressions and verify the fix for existing tests.

---
*PR created automatically by Jules for task [5267076503570817138](https://jules.google.com/task/5267076503570817138) started by @longMengchheang*