### PR TITLE
Remove unused frontend/lib/config.ts and fix broken progression tests

### DIFF
--- a/frontend/lib/config.ts
+++ b/frontend/lib/config.ts
@@ -1,1 +1,0 @@
-export const JWT_SECRET = process.env.JWT_SECRET || '4a8f5b3e2c1d9e7f6a5b4c3d2e1f0a9';

--- a/frontend/lib/progression.test.ts
+++ b/frontend/lib/progression.test.ts
@@ -1,5 +1,12 @@
 import { expect, test, describe } from "bun:test";
-import { applyXPDelta, getRequiredXP } from "./progression";
+import {
+  applyXPDelta,
+  getRequiredXP,
+  computeDailyStreak,
+  deriveBadges,
+  type BadgeContext,
+  getMoodFromCheckIn
+} from "./progression";
 
 describe("getRequiredXP", () => {
   test("should return base XP for level 1", () => {
@@ -27,8 +34,6 @@ describe("getRequiredXP", () => {
     expect(getRequiredXP(NaN)).toBe(100);
   });
 });
-import { applyXPDelta, computeDailyStreak } from "./progression";
-import { applyXPDelta, deriveBadges, type BadgeContext } from "./progression";
 
 describe("applyXPDelta", () => {
   test("should gain XP without leveling up", () => {
@@ -201,6 +206,9 @@ describe("computeDailyStreak", () => {
       new Date("2023-12-31T10:00:00"),
     ];
     expect(computeDailyStreak(dates)).toBe(2);
+  });
+});
+
 describe("deriveBadges", () => {
   const baseContext: BadgeContext = {
     totalQuests: 0,
@@ -288,6 +296,9 @@ describe("deriveBadges", () => {
     const badges = deriveBadges(context);
     expect(badges).toContain("First Quest");
     expect(badges.filter((b) => b === "First Quest").length).toBe(1);
+  });
+});
+
 describe("getMoodFromCheckIn", () => {
   test("should return 'Excellent' for scores >= 80%", () => {
     expect(getMoodFromCheckIn(20, 25)).toEqual({ emoji: '🤩', label: 'Excellent' }); // 80%


### PR DESCRIPTION
This PR removes the unused `frontend/lib/config.ts` file which contained a duplicate definition of `JWT_SECRET` with a hardcoded fallback. This improves code health by removing dead code and potential security confusion.

Additionally, this PR fixes syntax errors (missing closing braces) and messy imports in `frontend/lib/progression.test.ts`, allowing the test suite to run and pass successfully. This was necessary to verify that the removal of `config.ts` did not cause regressions.

**Verification:**
- Ran `bun test` in `frontend/` directory. All tests passed (after fixing `progression.test.ts`).
- Confirmed via `grep` that `frontend/lib/config.ts` is not imported anywhere else in the codebase.
- Attempted `npm run build` but encountered pre-existing errors unrelated to `config.ts`. The unit tests provide sufficient coverage for this change.

---
*PR created automatically by Jules for task [14089504343178359383](https://jules.google.com/task/14089504343178359383) started by @longMengchheang*