### PR TITLE
Refactor Quest schema: Replace ratings array with progress field

### DIFF
--- a/frontend/app/api/insight/map/route.ts
+++ b/frontend/app/api/insight/map/route.ts
@@ -386,7 +386,7 @@ export async function GET(req: Request) {
     const completionRate = questsRaw.length ? doneCount / questsRaw.length : 0;
 
     if (latestQuest) {
-      const progress = clamp(Array.isArray(latestQuest.ratings) ? Number(latestQuest.ratings[0] || 0) : 0, 0, 100);
+      const progress = clamp(Number(latestQuest.progress ?? latestQuest.ratings?.[0] ?? 0), 0, 100);
       const questScore = latestQuest.completed ? 100 : clamp100(progress * 0.8 + completionRate * 20);
       const labelRaw = String(latestQuest.goal || 'Quest').trim() || 'Quest';
       nodes.push({

--- a/frontend/app/api/quest/all/route.ts
+++ b/frontend/app/api/quest/all/route.ts
@@ -22,6 +22,7 @@ export async function GET(req: Request) {
       quests.map((quest) => ({
         ...quest,
         _id: String(quest._id),
+        progress: quest.progress ?? quest.ratings?.[0] ?? 0,
       })),
     );
   } catch (error) {

--- a/frontend/app/api/quest/complete/[id]/route.ts
+++ b/frontend/app/api/quest/complete/[id]/route.ts
@@ -36,7 +36,7 @@ export async function PUT(req: Request, { params }: RouteContext) {
 
     const nextCompleted = !quest.completed;
     quest.completed = nextCompleted;
-    quest.ratings = [nextCompleted ? 100 : 0];
+    quest.progress = nextCompleted ? 100 : 0;
     quest.completedDate = nextCompleted ? new Date() : null;
     await quest.save();
 

--- a/frontend/app/api/quest/create/route.ts
+++ b/frontend/app/api/quest/create/route.ts
@@ -37,7 +37,7 @@ export async function POST(req: Request) {
       userId: user.id,
       goal,
       duration,
-      ratings: [0],
+      progress: 0,
       completed: false,
       completedDate: null,
       date: new Date(),

--- a/frontend/app/api/quest/progress/[id]/route.ts
+++ b/frontend/app/api/quest/progress/[id]/route.ts
@@ -44,9 +44,9 @@ export async function PUT(req: Request, { params }: RouteContext) {
       return NextResponse.json({ msg: 'Quest not found.' }, { status: 404 });
     }
 
-    const previousProgress = Number(Array.isArray(quest.ratings) ? quest.ratings[0] : 0);
+    const previousProgress = Number(quest.progress ?? quest.ratings?.[0] ?? 0);
     const wasCompleted = quest.completed;
-    quest.ratings = [Math.round(progress)];
+    quest.progress = Math.round(progress);
     quest.completed = progress >= 100;
     quest.completedDate = quest.completed ? new Date() : null;
     await quest.save();

--- a/frontend/app/dashboard/quest/page.tsx
+++ b/frontend/app/dashboard/quest/page.tsx
@@ -18,7 +18,6 @@ interface Quest {
   id: string;
   goal: string;
   duration: string;
-  ratings: number[];
   progress: number;
   completed: boolean;
   createdAt: string;
@@ -112,7 +111,7 @@ export default function QuestLogPage() {
           _id: string;
           goal: string;
           duration: string;
-          ratings?: number[];
+          progress?: number;
           completed?: boolean;
           date?: string;
           createdAt?: string;
@@ -121,8 +120,7 @@ export default function QuestLogPage() {
           id: quest._id,
           goal: quest.goal,
           duration: quest.duration,
-          ratings: quest.ratings ?? [0],
-          progress: Number(quest.ratings?.[0] ?? 0),
+          progress: Number(quest.progress ?? 0),
           completed: Boolean(quest.completed),
           createdAt: quest.date ?? quest.createdAt ?? new Date().toISOString(),
           completedDate: quest.completedDate,
@@ -160,8 +158,7 @@ export default function QuestLogPage() {
         id: quest._id,
         goal: quest.goal,
         duration: quest.duration,
-        ratings: quest.ratings ?? [0],
-        progress: Number(quest.ratings?.[0] ?? 0),
+        progress: Number(quest.progress ?? 0),
         completed: Boolean(quest.completed),
         createdAt: quest.date ?? new Date().toISOString(),
       };
@@ -217,7 +214,7 @@ export default function QuestLogPage() {
       );
 
       const updatedQuest = response.data?.quest;
-      updateQuestState(id, Number(updatedQuest?.ratings?.[0] ?? normalizedProgress), Boolean(updatedQuest?.completed));
+      updateQuestState(id, Number(updatedQuest?.progress ?? normalizedProgress), Boolean(updatedQuest?.completed));
     } catch {
       addToast("Update failed", "Could not update quest progress.", "error");
     }
@@ -235,7 +232,7 @@ export default function QuestLogPage() {
       );
 
       const updatedQuest = response.data?.quest;
-      updateQuestState(id, Number(updatedQuest?.ratings?.[0] ?? 0), Boolean(updatedQuest?.completed));
+      updateQuestState(id, Number(updatedQuest?.progress ?? 0), Boolean(updatedQuest?.completed));
     } catch {
       addToast("Completion failed", "Could not update quest completion.", "error");
     }

--- a/frontend/lib/models/Quest.ts
+++ b/frontend/lib/models/Quest.ts
@@ -1,28 +1,27 @@
-﻿import mongoose, { Document, Model } from 'mongoose';
+import mongoose, { Document, Model } from 'mongoose';
 
 export interface IQuest extends Document {
   userId: mongoose.Types.ObjectId;
   goal: string;
   duration: 'daily' | 'weekly' | 'monthly' | 'yearly';
-  ratings: number[];
-  progress: number;
+  progress?: number;
+  ratings?: number[];
   completed: boolean;
   date: Date;
   completedDate?: Date;
-}
-
-function progressLimit(values: number[]): boolean {
-  return Array.isArray(values) && values.length === 1 && values[0] >= 0 && values[0] <= 100;
 }
 
 const questSchema = new mongoose.Schema({
   userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
   goal: { type: String, required: true, trim: true, maxlength: 100 },
   duration: { type: String, enum: ['daily', 'weekly', 'monthly', 'yearly'], required: true },
-  ratings: {
-    type: [Number],
-    required: true,
-    validate: [progressLimit, 'Progress must be a single value between 0 and 100'],
+  // Keep ratings for backward compatibility
+  ratings: { type: [Number], default: undefined },
+  progress: {
+    type: Number,
+    min: 0,
+    max: 100,
+    // Not required to support legacy documents
   },
   completed: { type: Boolean, default: false },
   completedDate: { type: Date, default: null },


### PR DESCRIPTION
This PR addresses the "Confusing Data Model in Quest Schema" issue by migrating the `Quest` model to use a `progress` number field instead of a single-element `ratings` array.

Changes:
-   `frontend/lib/models/Quest.ts`: Added `progress` field (Number, min 0, max 100). Kept `ratings` field (optional) for backward compatibility. Removed `progressLimit` validator.
-   `frontend/app/api/quest/create/route.ts`: Initialize new quests with `progress: 0`.
-   `frontend/app/api/quest/progress/[id]/route.ts`: Update `progress` field. Read using fallback logic.
-   `frontend/app/api/quest/complete/[id]/route.ts`: Update `progress` field on completion/reopen.
-   `frontend/app/api/insight/map/route.ts`: Read using fallback logic.
-   `frontend/app/api/quest/all/route.ts`: Return objects with `progress` populated (using fallback if needed) so frontend interface is consistent.
-   `frontend/app/dashboard/quest/page.tsx`: Updated `Quest` interface and component logic to use `progress`.

Verification:
-   Created a custom verification script (`verify_quest_v2.ts`) using `mongodb-memory-server` and `mongoose`.
-   Verified that creating a new quest sets `progress` and not `ratings`.
-   Verified that a legacy quest (inserted directly with `ratings` and no `progress`) is read correctly via fallback.
-   Verified that updating a legacy quest sets the new `progress` field.
-   Verified TypeScript compilation (with existing unrelated errors noted).

---
*PR created automatically by Jules for task [8792160850319019127](https://jules.google.com/task/8792160850319019127) started by @longMengchheang*