### PR TITLE
Refactor profile route authentication

### DIFF
--- a/frontend/app/api/profile/route.ts
+++ b/frontend/app/api/profile/route.ts
@@ -1,6 +1,6 @@
 ﻿import { NextResponse } from 'next/server';
 import dbConnect from '@/lib/db';
-import { verifyToken } from '@/lib/auth';
+import { withAuth } from '@/lib/auth';
 import { computeDailyStreak, deriveBadges, getMoodFromCheckIn } from '@/lib/progression';
 import CheckIn from '@/lib/models/CheckIn';
 import Quest from '@/lib/models/Quest';
@@ -72,14 +72,9 @@ async function buildProfile(userId: string) {
   };
 }
 
-export async function GET(req: Request) {
+export const GET = withAuth(async (req, _context, user) => {
   try {
     await dbConnect();
-
-    const user = verifyToken(req);
-    if (!user) {
-      return NextResponse.json({ msg: 'No token, authorization denied.' }, { status: 401 });
-    }
 
     const profile = await buildProfile(user.id);
     if (!profile) {
@@ -91,16 +86,11 @@ export async function GET(req: Request) {
     console.error('Profile fetch error:', error);
     return NextResponse.json({ msg: 'Server error.' }, { status: 500 });
   }
-}
+});
 
-export async function PUT(req: Request) {
+export const PUT = withAuth(async (req, _context, authUser) => {
   try {
     await dbConnect();
-
-    const authUser = verifyToken(req);
-    if (!authUser) {
-      return NextResponse.json({ msg: 'No token, authorization denied.' }, { status: 401 });
-    }
 
     const user = await User.findById(authUser.id);
     if (!user) {
@@ -161,4 +151,4 @@ export async function PUT(req: Request) {
     console.error('Profile update error:', error);
     return NextResponse.json({ msg: 'Server error.' }, { status: 500 });
   }
-}
+});

--- a/frontend/lib/auth.test.ts
+++ b/frontend/lib/auth.test.ts
@@ -1,0 +1,97 @@
+import { describe, test, expect, mock } from 'bun:test';
+import { verifyToken, signToken, DecodedUser, withAuth } from './auth';
+import { NextResponse } from 'next/server';
+
+// Set JWT_SECRET for testing
+process.env.JWT_SECRET = 'test-secret';
+
+describe('Auth Utilities', () => {
+  const mockUser: DecodedUser = {
+    id: 'user123',
+    email: 'test@example.com',
+  };
+
+  describe('withAuth', () => {
+    test('blocks unauthorized request', async () => {
+      const handler = mock(async (_req: Request, _context: any, _user: DecodedUser) => {
+        return NextResponse.json({ success: true });
+      });
+
+      const wrappedHandler = withAuth(handler);
+      const req = new Request('http://localhost');
+      const res = await wrappedHandler(req, {});
+
+      expect(res.status).toBe(401);
+      const json = await res.json();
+      expect(json).toEqual({ msg: 'No token, authorization denied.' });
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    test('allows authorized request', async () => {
+      const handler = mock(async (_req: Request, _context: any, user: DecodedUser) => {
+        return NextResponse.json({ success: true, userId: user.id });
+      });
+
+      const token = signToken(mockUser);
+      const wrappedHandler = withAuth(handler);
+      const req = new Request('http://localhost', {
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+      });
+
+      const res = await wrappedHandler(req, {});
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json).toEqual({ success: true, userId: mockUser.id });
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test('signToken generates a token', () => {
+    const token = signToken(mockUser);
+    expect(token).toBeString();
+    expect(token.length).toBeGreaterThan(0);
+  });
+
+  test('verifyToken returns user for valid token', () => {
+    const token = signToken(mockUser);
+    const req = new Request('http://localhost', {
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    });
+
+    const user = verifyToken(req);
+    expect(user).not.toBeNull();
+    expect(user?.id).toBe(mockUser.id);
+    expect(user?.email).toBe(mockUser.email);
+  });
+
+  test('verifyToken returns null for missing header', () => {
+    const req = new Request('http://localhost');
+    const user = verifyToken(req);
+    expect(user).toBeNull();
+  });
+
+  test('verifyToken returns null for invalid token', () => {
+    const req = new Request('http://localhost', {
+      headers: {
+        authorization: 'Bearer invalid.token.here',
+      },
+    });
+    const user = verifyToken(req);
+    expect(user).toBeNull();
+  });
+
+  test('verifyToken returns null for malformed header', () => {
+    const req = new Request('http://localhost', {
+      headers: {
+        authorization: 'Basic token',
+      },
+    });
+    const user = verifyToken(req);
+    expect(user).toBeNull();
+  });
+});

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -1,4 +1,6 @@
 import jwt from 'jsonwebtoken';
+import { NextResponse } from 'next/server';
+import { unauthorized } from './api-response';
 
 if (!process.env.JWT_SECRET) {
   throw new Error('JWT_SECRET is not defined');
@@ -37,4 +39,16 @@ export function verifyToken(req: Request): DecodedUser | null {
   } catch {
     return null;
   }
+}
+
+export function withAuth<T = any>(
+  handler: (req: Request, context: T, user: DecodedUser) => Promise<NextResponse>
+) {
+  return async (req: Request, context: T) => {
+    const user = verifyToken(req);
+    if (!user) {
+      return unauthorized();
+    }
+    return handler(req, context, user);
+  };
 }


### PR DESCRIPTION
This PR refactors the authentication logic in `frontend/app/api/profile/route.ts` by introducing a `withAuth` higher-order function in `frontend/lib/auth.ts`. This reduces code duplication and standardizes authentication checks across route handlers. A new test file `frontend/lib/auth.test.ts` has been added to verify the authentication logic and prevent regressions.


---
*PR created automatically by Jules for task [14577825817113113611](https://jules.google.com/task/14577825817113113611) started by @longMengchheang*