### PR TITLE
🧪 Add tests for verifyToken in auth.ts

### DIFF
--- a/frontend/bunfig.toml
+++ b/frontend/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./test-setup.ts"]

--- a/frontend/lib/auth.test.ts
+++ b/frontend/lib/auth.test.ts
@@ -1,0 +1,77 @@
+import { describe, test, expect, beforeAll } from "bun:test";
+
+import { verifyToken, signToken, type DecodedUser } from "./auth";
+import jwt from "jsonwebtoken";
+
+describe("verifyToken", () => {
+  const mockUser: DecodedUser = {
+    id: "user123",
+    email: "test@example.com",
+  };
+
+  test("should return null if authorization header is missing", () => {
+    const req = new Request("http://localhost", {
+      headers: {},
+    });
+    expect(verifyToken(req)).toBeNull();
+  });
+
+  test("should return null if authorization header does not start with Bearer", () => {
+    const req = new Request("http://localhost", {
+      headers: {
+        authorization: "Basic somecredential",
+      },
+    });
+    expect(verifyToken(req)).toBeNull();
+  });
+
+  test("should return null if token is missing after Bearer", () => {
+    const req = new Request("http://localhost", {
+      headers: {
+        authorization: "Bearer ", // just whitespace
+      },
+    });
+    expect(verifyToken(req)).toBeNull();
+  });
+
+  test("should return null if token is invalid", () => {
+    const req = new Request("http://localhost", {
+      headers: {
+        authorization: "Bearer invalid.token.string",
+      },
+    });
+    expect(verifyToken(req)).toBeNull();
+  });
+
+  test("should return decoded user if token is valid", () => {
+    const token = signToken(mockUser);
+    const req = new Request("http://localhost", {
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    });
+
+    const result = verifyToken(req);
+    expect(result).not.toBeNull();
+    expect(result?.id).toBe(mockUser.id);
+    expect(result?.email).toBe(mockUser.email);
+  });
+
+  test("should return null if token is expired", () => {
+    // Manually create an expired token
+    // Note: The payload structure in auth.ts is { user: DecodedUser }
+    const expiredToken = jwt.sign(
+      { user: mockUser },
+      process.env.JWT_SECRET!,
+      { expiresIn: "-1s" } // expired 1 second ago
+    );
+
+    const req = new Request("http://localhost", {
+      headers: {
+        authorization: `Bearer ${expiredToken}`,
+      },
+    });
+
+    expect(verifyToken(req)).toBeNull();
+  });
+});

--- a/frontend/test-setup.ts
+++ b/frontend/test-setup.ts
@@ -1,0 +1,1 @@
+process.env.JWT_SECRET = "test-secret";


### PR DESCRIPTION
This PR adds a comprehensive test suite for the `verifyToken` function in `frontend/lib/auth.ts`. It covers various scenarios including missing headers, malformed tokens, invalid signatures, and expired tokens. Additionally, it sets up the `bun test` environment configuration to ensure tests run reliably with the required environment variables.

---
*PR created automatically by Jules for task [7267425695783419082](https://jules.google.com/task/7267425695783419082) started by @longMengchheang*