### PR TITLE
chore: remove unused formatHistoryTime function in chat page

### DIFF
--- a/src/app/dashboard/chat/page.tsx
+++ b/src/app/dashboard/chat/page.tsx
@@ -56,16 +56,6 @@ function toUiMessage(message: ServerMessage, fallbackId: string): ChatMessage | 
   };
 }
 
-function formatHistoryTime(value: string): string {
-  const date = new Date(value);
-  return date.toLocaleString([], {
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-}
-
 export default function CompanionPage() {
   const router = useRouter();
 


### PR DESCRIPTION
Removed the unused `formatHistoryTime` function from `src/app/dashboard/chat/page.tsx` to improve code health and remove dead code. This function was not exported and not used within the file. Validated that the file still transpiles correctly.

---
*PR created automatically by Jules for task [14851987590656769375](https://jules.google.com/task/14851987590656769375) started by @longMengchheang*