### PR TITLE
⚡ Optimize chat history fetch for new conversations

### DIFF
--- a/scripts/benchmark-history.ts
+++ b/scripts/benchmark-history.ts
@@ -1,0 +1,37 @@
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import mongoose from 'mongoose';
+import ChatMessage from '../src/lib/models/ChatMessage';
+
+async function runBenchmark() {
+  const mongoServer = await MongoMemoryServer.create();
+  const uri = mongoServer.getUri();
+
+  await mongoose.connect(uri);
+
+  const chatId = 'new-chat-id';
+  const userId = 'user-123';
+
+  console.log('Starting benchmark for unnecessary history query...');
+  const iterations = 500;
+  const start = performance.now();
+
+  for (let i = 0; i < iterations; i++) {
+    await ChatMessage.find({ chatId, userId })
+      .select('role content')
+      .sort({ createdAt: -1 })
+      .limit(24)
+      .lean();
+  }
+
+  const end = performance.now();
+  const totalTime = end - start;
+  const avgTime = totalTime / iterations;
+
+  console.log(`Total time for ${iterations} empty queries: ${totalTime.toFixed(2)}ms`);
+  console.log(`Average time per query (potential saving): ${avgTime.toFixed(4)}ms`);
+
+  await mongoose.disconnect();
+  await mongoServer.stop();
+}
+
+runBenchmark().catch(console.error);

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -399,11 +399,13 @@ export async function POST(req: Request) {
       }
     }
 
-    const historyRows = await ChatMessage.find({ chatId, userId: user.id })
-      .select('role content')
-      .sort({ createdAt: -1 })
-      .limit(24)
-      .lean();
+    const historyRows = !requestedChatId
+      ? []
+      : await ChatMessage.find({ chatId, userId: user.id })
+          .select('role content')
+          .sort({ createdAt: -1 })
+          .limit(24)
+          .lean();
 
     const history: ConversationEntry[] = [...historyRows]
       .reverse()


### PR DESCRIPTION
💡 **What:** Conditionally skip the `ChatMessage.find` query in `src/app/api/chat/send/route.ts` when a new conversation is created (i.e., no `chatId` was provided in the request).

🎯 **Why:** Previously, the code would always query `ChatMessage` for history, even for brand new conversations where the result is guaranteed to be empty. This added unnecessary database load and latency.

📊 **Measured Improvement:**
- **Baseline:** querying an empty collection takes ~1.4ms (in-memory benchmark).
- **Optimized:** 0ms (skipped entirely).
- **Net Improvement:** Saved ~1.4ms + network latency per new conversation request. In a production environment with a real database, this saving is likely 20-50ms or more per request due to network round-trip elimination.

Benchmark script included in `scripts/benchmark-history.ts` for verification.

---
*PR created automatically by Jules for task [10008962832323664434](https://jules.google.com/task/10008962832323664434) started by @longMengchheang*