### PR TITLE
🧹 Remove duplicate clamp function in insight-map.ts

### DIFF
--- a/src/lib/insight-map.ts
+++ b/src/lib/insight-map.ts
@@ -1,4 +1,5 @@
 import { normalizeSignalType } from '@/lib/chat-signals';
+import { clamp } from '@/lib/math';
 
 export type NodeType = 'Mood' | 'Signal' | 'Habit' | 'Routine' | 'Quest';
 export type NodeState = 'low' | 'medium' | 'high';
@@ -122,7 +123,6 @@ const NODE_PALETTE: Record<NodeType, Record<NodeState, string>> = {
   Quest: { low: '#c4b5fd', medium: '#a78bfa', high: '#8b5cf6' },
 };
 
-const clamp = (v: number, min: number, max: number) => Math.max(min, Math.min(max, v));
 const clamp100 = (v: number) => clamp(Math.round(v), 0, 100);
 const avg = (arr: number[]) => (arr.length ? arr.reduce((s, v) => s + v, 0) / arr.length : 0);
 const startDay = (d: Date) => { const n = new Date(d); n.setHours(0, 0, 0, 0); return n; };


### PR DESCRIPTION
This change addresses a code health issue where the `clamp` function was duplicated in `src/lib/insight-map.ts`. 

- Imported `clamp` from `@/lib/math`.
- Removed the local definition of `clamp` in `src/lib/insight-map.ts`.
- Verified that `clamp100` and other usages correctly reference the imported function.
- Confirmed the file's integrity using `bun build`.

---
*PR created automatically by Jules for task [1685482899263392358](https://jules.google.com/task/1685482899263392358) started by @longMengchheang*