### PR TITLE
🧹 Improve type safety for Mongoose models in streaks analytics

### DIFF
--- a/src/lib/analytics/streaks.ts
+++ b/src/lib/analytics/streaks.ts
@@ -18,9 +18,8 @@ export interface StreakReport {
   overallStreak: number;
 }
 
-async function getDatesByField(
-  // eslint-disable-next-line
-  model: mongoose.Model<any>,
+async function getDatesByField<T>(
+  model: mongoose.Model<T>,
   userId: mongoose.Types.ObjectId,
   dateField: string,
   extraFilter: Record<string, unknown> = {},


### PR DESCRIPTION
- 🎯 **What:** Replaced `mongoose.Model<any>` with a generic `mongoose.Model<T>` in the `getDatesByField` utility function and removed the corresponding `eslint-disable-next-line` comment.
- 💡 **Why:** Improves maintainability and adheres to linting standards by avoiding `any` where a generic type is more appropriate and type-safe.
- ✅ **Verification:** Verified by running `bun test src/lib/analytics/streaks.test.ts` (with necessary environment mocks) and manual code inspection.
- ✨ **Result:** Cleaner, more type-safe code that no longer requires lint suppression.

---
*PR created automatically by Jules for task [3930370521998273781](https://jules.google.com/task/3930370521998273781) started by @mengchheanglong*