### PR TITLE
🧹 Refactor buildProfile to use specific User and CheckIn types

### DIFF
--- a/src/lib/profile-service.ts
+++ b/src/lib/profile-service.ts
@@ -1,11 +1,11 @@
 import { computeDailyStreak, deriveBadges, getMoodFromCheckIn } from '@/lib/progression';
-import CheckIn from '@/lib/models/CheckIn';
+import CheckIn, { ICheckIn } from '@/lib/models/CheckIn';
 import Quest from '@/lib/models/Quest';
-import User from '@/lib/models/User';
+import User, { IUser } from '@/lib/models/User';
 import { formatJoinDate } from '@/lib/date';
 
-export async function buildProfile(userId: string, userObj?: Record<string, any>) {
-  let user = userObj;
+export async function buildProfile(userId: string, userObj?: Partial<IUser> | null) {
+  let user: Partial<IUser> | null = userObj || null;
 
   if (!user) {
     user = await User.findById(userId)
@@ -25,7 +25,7 @@ export async function buildProfile(userId: string, userObj?: Record<string, any>
         .sort({ date: -1 })
         .limit(180)
         .select('date overallScore ratings')
-        .lean(),
+        .lean() as Promise<Partial<ICheckIn>[]>,
       Quest.countDocuments({
         userId,
         completed: true,


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was the use of `any` (via `Record<string, any>`) in the `buildProfile` function's `userObj` parameter.
💡 **Why:** Replacing `any` with `Partial<IUser> | null` improves type safety, maintainability, and readability of the `profile-service.ts` file. It also provides better developer experience through IDE autocompletion and early error detection.
✅ **Verification:** Confirmed the changes by reading the modified file and running `bun build src/lib/profile-service.ts --target bun --no-bundle` to ensure there are no TypeScript syntax errors. Received a positive code review confirming the logic and types are correct.
✨ **Result:** Improved type safety in `src/lib/profile-service.ts` without changing any existing functionality.

---
*PR created automatically by Jules for task [11722079682944085994](https://jules.google.com/task/11722079682944085994) started by @mengchheanglong*