### PR TITLE
🧹 Remove debug console logs in QuestLogPage

### DIFF
--- a/src/app/dashboard/quest/page.tsx
+++ b/src/app/dashboard/quest/page.tsx
@@ -184,7 +184,6 @@ export default function QuestLogPage() {
       );
 
       setQuests(mapped);
-      console.log('[Frontend] Mapped Quests:', mapped);
     } catch {
       addToast("Quest sync failed", "Unable to load quest log.", "error");
     }
@@ -200,7 +199,6 @@ export default function QuestLogPage() {
       });
 
       setQuestLogs(response.data?.questLogs ?? []);
-      console.log('[Frontend] Quest Logs:', response.data?.questLogs);
     } catch {
       console.error("Failed to fetch quest logs");
     }
@@ -232,7 +230,6 @@ export default function QuestLogPage() {
             duration,
             recurrences: recurrences ? parseInt(recurrences) : undefined
       };
-      console.log('[Frontend] Creating Quest Payload:', payload);
 
       const response = await axios.post(
         "/api/quest/create",


### PR DESCRIPTION
🎯 **What:** Removed several debug `console.log` statements from the Quest Log frontend page (`src/app/dashboard/quest/page.tsx`).
💡 **Why:** These logs were used for development debugging and are no longer needed. Removing them improves maintainability and reduces client-side noise.
✅ **Verification:** Verified the removal using `grep` and confirmed that the file still builds correctly using `bun build`.
✨ **Result:** Cleaned up the frontend console output for a better user and developer experience.

---
*PR created automatically by Jules for task [15125249410371860116](https://jules.google.com/task/15125249410371860116) started by @mengchheanglong*