### PR TITLE
🔒 Add Rate Limiting to User Registration

### DIFF
--- a/src/app/api/auth/register/rate-limit.test.ts
+++ b/src/app/api/auth/register/rate-limit.test.ts
@@ -1,0 +1,75 @@
+import { expect, test, describe, mock, beforeEach } from "bun:test";
+
+// Mock dependencies before importing the route
+mock.module("@/lib/db", () => ({
+  default: mock(() => Promise.resolve()),
+}));
+
+mock.module("@/lib/api-response", () => ({
+  badRequest: (msg: string) => new Response(JSON.stringify({ msg }), { status: 400 }),
+  tooManyRequests: (msg: string) => new Response(JSON.stringify({ msg }), { status: 429 }),
+  serverError: (err: any, msg: string) => new Response(JSON.stringify({ msg }), { status: 500 }),
+  conflict: (msg: string) => new Response(JSON.stringify({ msg }), { status: 409 }),
+}));
+
+mock.module("@/lib/models/User", () => ({
+  default: {
+    findOne: mock(() => Promise.resolve(null)),
+    prototype: {
+      save: mock(() => Promise.resolve()),
+    },
+  },
+}));
+
+mock.module("@/lib/auth", () => ({
+  signToken: () => "mock-token",
+}));
+
+mock.module("@/lib/validation", () => ({
+  validateEmail: () => ({ isValid: true }),
+  validatePassword: () => ({ isValid: true }),
+}));
+
+mock.module("@/lib/progression", () => ({
+  getRequiredXP: () => 100,
+}));
+
+import { POST } from "./route";
+
+describe("Registration Rate Limiting", () => {
+  const createRequest = (ip: string) => {
+    return new Request("http://localhost/api/auth/register", {
+      method: "POST",
+      headers: {
+        "x-forwarded-for": ip,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ email: "test@example.com", password: "password123" }),
+    });
+  };
+
+  test("should allow up to 5 requests and then block the 6th", async () => {
+    const ip = "1.2.3.4";
+
+    // First 5 requests should pass (or at least not fail due to rate limiting)
+    for (let i = 0; i < 5; i++) {
+      const req = createRequest(ip);
+      const res = await POST(req);
+      expect(res.status).not.toBe(429);
+    }
+
+    // 6th request should be rate limited
+    const req6 = createRequest(ip);
+    const res6 = await POST(req6);
+    expect(res6.status).toBe(429);
+    const data = await res6.json();
+    expect(data.msg).toBe("Too many registration attempts. Please try again later.");
+  });
+
+  test("should allow requests from different IPs", async () => {
+    const ip2 = "5.6.7.8";
+    const req = createRequest(ip2);
+    const res = await POST(req);
+    expect(res.status).not.toBe(429);
+  });
+});

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -5,9 +5,13 @@ import { signToken } from '@/lib/auth';
 import { validatePassword, validateEmail } from '@/lib/validation';
 import { getRequiredXP } from '@/lib/progression';
 import User from '@/lib/models/User';
-import { badRequest, conflict, serverError } from '@/lib/api-response';
+import { badRequest, conflict, serverError, tooManyRequests } from '@/lib/api-response';
+import { RateLimiter } from '@/lib/rate-limit';
 
 export const dynamic = 'force-dynamic';
+
+// 5 requests per minute
+const registerLimiter = new RateLimiter(60 * 1000, 5);
 
 interface RegisterPayload {
   email?: string;
@@ -28,6 +32,13 @@ function buildNameFromEmail(email: string): string {
 
 export async function POST(req: Request) {
   try {
+    const forwarded = req.headers.get('x-forwarded-for');
+    const ip = forwarded ? forwarded.split(',')[0].trim() : 'unknown';
+
+    if (!registerLimiter.check(ip)) {
+      return tooManyRequests('Too many registration attempts. Please try again later.');
+    }
+
     await dbConnect();
 
     const body = (await req.json()) as RegisterPayload;


### PR DESCRIPTION
This PR addresses a security vulnerability where the user registration endpoint lacked rate limiting, making it susceptible to automated spam and brute-force attacks.

### Changes:
- Integrated `RateLimiter` from `@/lib/rate-limit` into `src/app/api/auth/register/route.ts`.
- Configured a limit of 5 registration attempts per minute per IP address.
- Added a new test file `src/app/api/auth/register/rate-limit.test.ts` to verify the functionality.

### Verification:
- Unit tests pass with `bun test`.
- Manual verification of syntax using `bun build`.
- Code review completed and changes validated.

---
*PR created automatically by Jules for task [12762420245724243733](https://jules.google.com/task/12762420245724243733) started by @mengchheanglong*