### PR TITLE
🧹 Replace 'any' Type In Error Signature in email.ts

### DIFF
--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -4,7 +4,7 @@ interface SendEmailOptions {
   html: string;
 }
 
-export const sendEmail = async ({ to, subject, html }: SendEmailOptions): Promise<{ success: boolean; error?: any }> => {
+export const sendEmail = async ({ to, subject, html }: SendEmailOptions): Promise<{ success: boolean; error?: unknown }> => {
   console.log('----------------------------------------');
   console.log('📧 EMAILS ARE DISABLED (SIMPLIFIED MODE)');
   console.log(`To: ${to}`);


### PR DESCRIPTION
🎯 **What:** Replaced the `any` type in the `error` property of the `sendEmail` function's return signature with `unknown` in `src/lib/email.ts`.

💡 **Why:** Returning `any` as an error type hides typing information and can lead to unsafe property access. Using `unknown` is a safer alternative that requires explicit type checking or narrowing.

✅ **Verification:** 
- Verified the syntax of `src/lib/email.ts` using `bun build`.
- Verified that the change does not break dependent files like `src/app/api/auth/forgot-password/route.ts` using `bun build`.
- Ran `bun test` to ensure no regressions (no test files found in project).
- Received positive code review.

✨ **Result:** Improved type safety for the `sendEmail` utility function.

---
*PR created automatically by Jules for task [13416219784436321854](https://jules.google.com/task/13416219784436321854) started by @mengchheanglong*