### PR TITLE
🧹 [code health] Remove frontend debug log for mapped quests

### DIFF
--- a/src/app/dashboard/quest/page.tsx
+++ b/src/app/dashboard/quest/page.tsx
@@ -184,7 +184,6 @@ export default function QuestLogPage() {
       );
 
       setQuests(mapped);
-      console.log('[Frontend] Mapped Quests:', mapped);
     } catch {
       addToast("Quest sync failed", "Unable to load quest log.", "error");
     }


### PR DESCRIPTION
Removed a redundant console.log statement in the quest dashboard that was logging mapped quests. This improves production console cleanliness.

---
*PR created automatically by Jules for task [4966680384871401703](https://jules.google.com/task/4966680384871401703) started by @mengchheanglong*